### PR TITLE
Refactor frontend API calls to Axios services

### DIFF
--- a/parkulator-frontend/app.json
+++ b/parkulator-frontend/app.json
@@ -19,7 +19,8 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "edgeToEdgeEnabled": true,
-      "predictiveBackGestureEnabled": false
+      "predictiveBackGestureEnabled": false,
+      "package": "com.anonymous.parkulatorfrontend"
     },
     "web": {
       "output": "static",

--- a/parkulator-frontend/app/EditProfile.tsx
+++ b/parkulator-frontend/app/EditProfile.tsx
@@ -1,10 +1,15 @@
 import React, { useState } from "react";
 import { View, Text, TextInput, TouchableOpacity, StyleSheet, Alert } from "react-native";
-import AsyncStorage from "@react-native-async-storage/async-storage";
+//import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useRouter } from "expo-router";
 import { useAuth } from "../context/AuthContext";
+import {
+  updateUsernameRequest,
+  updateEmailRequest,
+  updatePasswordRequest,
+} from "../services/user";
 
-const API_URL = "http://192.168.1.4:8080";
+import { getApiErrorMessage } from "../services/api";
 
 export default function EditProfile() {
   const router = useRouter();
@@ -16,7 +21,6 @@ export default function EditProfile() {
   const [newPassword, setNewPassword] = useState("");
   const [loading, setLoading] = useState(false);
 
-  const getToken = async () => await AsyncStorage.getItem("auth_token");
 
   const updateUsername = async () => {
     if (!username.trim()) {
@@ -25,28 +29,17 @@ export default function EditProfile() {
     }
 
     setLoading(true);
-    try {
-      const token = await getToken();
-      const res = await fetch(`${API_URL}/users/username`, {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify({ username: username.trim() }),
-      });
 
-      if (res.ok) {
-        await updateUser({ username: username.trim() });
-        Alert.alert("Success", "Username updated");
-        setUsername("");
-        router.back();
-      } else {
-        const msg = await res.text();
-        Alert.alert("Error", msg || "Failed to update username");
-      }
+    try {
+      await updateUsernameRequest(username.trim());
+
+      await updateUser({ username: username.trim() });
+
+      Alert.alert("Success", "Username updated");
+      setUsername("");
+      router.back();
     } catch (e) {
-      Alert.alert("Error", "Could not connect to server");
+      Alert.alert("Error", getApiErrorMessage(e, "Failed to update username"));
     } finally {
       setLoading(false);
     }
@@ -59,39 +52,25 @@ export default function EditProfile() {
     }
 
     setLoading(true);
-    try {
-      const token = await getToken();
-      const res = await fetch(`${API_URL}/users/email`, {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify({ email: email.trim() }),
-      });
 
-      if (res.ok) {
-        // IMPORTANT: JWT token still contains the old email in the 'sub' claim.
-        // Until the backend returns a new token, the safest option is to log the user out.
-        Alert.alert(
-          "Email updated",
-          "Please log in again with your new email.",
-          [
-            {
-              text: "OK",
-              onPress: async () => {
-                await signOut();
-                router.replace("/login");
-              },
+    try {
+      await updateEmailRequest(email.trim());
+
+      Alert.alert(
+        "Email updated",
+        "Please log in again with your new email.",
+        [
+          {
+            text: "OK",
+            onPress: async () => {
+              await signOut();
+              router.replace("/login");
             },
-          ]
-        );
-      } else {
-        const msg = await res.text();
-        Alert.alert("Error", msg || "Failed to update email");
-      }
+          },
+        ]
+      );
     } catch (e) {
-      Alert.alert("Error", "Could not connect to server");
+      Alert.alert("Error", getApiErrorMessage(e, "Failed to update email"));
     } finally {
       setLoading(false);
     }
@@ -102,38 +81,28 @@ export default function EditProfile() {
       Alert.alert("Error", "Please fill in both password fields");
       return;
     }
+
     if (newPassword.length < 6) {
       Alert.alert("Error", "New password must be at least 6 characters");
       return;
     }
+
     if (oldPassword === newPassword) {
       Alert.alert("Error", "New password must be different from the old one");
       return;
     }
 
     setLoading(true);
-    try {
-      const token = await getToken();
-      const res = await fetch(`${API_URL}/users/password`, {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify({ oldPassword, newPassword }),
-      });
 
-      if (res.ok) {
-        Alert.alert("Success", "Password changed");
-        setOldPassword("");
-        setNewPassword("");
-        router.back();
-      } else {
-        const msg = await res.text();
-        Alert.alert("Error", msg || "Incorrect old password");
-      }
+    try {
+      await updatePasswordRequest(oldPassword, newPassword);
+
+      Alert.alert("Success", "Password changed");
+      setOldPassword("");
+      setNewPassword("");
+      router.back();
     } catch (e) {
-      Alert.alert("Error", "Could not connect to server");
+      Alert.alert("Error", getApiErrorMessage(e, "Incorrect old password"));
     } finally {
       setLoading(false);
     }

--- a/parkulator-frontend/app/Login.tsx
+++ b/parkulator-frontend/app/Login.tsx
@@ -5,28 +5,34 @@ import Input from "../components/ui/Input";
 import Button from "../components/ui/Button";
 import { useAuth } from "../context/AuthContext";
 import { loginRequest } from "../services/auth";
+import { getApiErrorMessage } from "../services/api";
 
 
 export default function Login() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
   const router = useRouter();
   const { signIn } = useAuth();
 
 
   const handleLogin = async () => {
-    try {
-      const data = await loginRequest({
-        email,
-        password,
-      });
+  setLoading(true);
 
-      await signIn(data);
-      router.replace("/");
-    } catch (error: any) {
-      Alert.alert("Login error", error?.message || "Neuspješna prijava");
-    }
-  };
+  try {
+    const data = await loginRequest({
+      email: email.trim(),
+      password,
+    });
+
+    await signIn(data);
+    router.replace("/(tabs)");
+  } catch (e) {
+    Alert.alert("Login failed", getApiErrorMessage(e, "Invalid email or password"));
+  } finally {
+    setLoading(false);
+  }
+};
 
 
   return (

--- a/parkulator-frontend/app/Register.tsx
+++ b/parkulator-frontend/app/Register.tsx
@@ -5,29 +5,34 @@ import Input from "../components/ui/Input";
 import Button from "../components/ui/Button";
 import { useAuth } from "../context/AuthContext";
 import { registerRequest } from "../services/auth";
+import { getApiErrorMessage } from "../services/api";
 
 export default function Register() {
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
   const router = useRouter();
   const { signIn } = useAuth();
 
   const handleRegister = async () => {
-    try {
-      const data = await registerRequest({
-        email,
-        username,
-        password,
-      });
+  setLoading(true);
 
-      await signIn(data);
-      router.replace("/");
-    } catch (error: any) {
-      Alert.alert("Register error", error?.message || "Neuspješna registracija");
-    }
-  };
+  try {
+    const data = await registerRequest({
+      email: email.trim(),
+      username: username.trim(),
+      password,
+    });
 
+    await signIn(data);
+    router.replace("/(tabs)");
+  } catch (e) {
+    Alert.alert("Registration failed", getApiErrorMessage(e, "Registration failed"));
+  } finally {
+    setLoading(false);
+  }
+};
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Create account</Text>

--- a/parkulator-frontend/app/allparkings.tsx
+++ b/parkulator-frontend/app/allparkings.tsx
@@ -3,19 +3,8 @@ import { View, Text, FlatList, ActivityIndicator, Linking, TouchableOpacity } fr
 import { blue, green } from "react-native-reanimated/lib/typescript/Colors";
 import { Stack } from "expo-router";
 import { useColorScheme } from "react-native";
+import { getAllParkingsRequest, Parking } from "../services/parking";
 
-interface Parking {
-  id: number;
-  sourceKey: string;
-  name: string;
-  address: string;
-  link: string;
-  type: string;
-  isLive: boolean;
-  spots: number;
-  availableSpots: number;
-  parkingPrices: any[];
-}
 
 const AllParkings = () => {
   const [parkings, setParkings] = useState<Parking[]>([]);
@@ -25,41 +14,21 @@ const AllParkings = () => {
   const isDark = colorScheme === "dark";  
 
   const fetchParkings = async () => {
-    console.log("FETCHING PARKINGS...");
-  
-    try {
-      const response = await fetch("http://192.168.1.105:8080/parkings/all");
-  
-      console.log("STATUS:", response.status);
-  
-      const text = await response.text();
-      console.log("RAW RESPONSE:", text);
-  
-      let data = [];
-  
-      if (text) {
-        try {
-          data = JSON.parse(text);
-        } catch (jsonError) {
-          console.log("JSON PARSE ERROR:", jsonError);
-          data = [];
-        }
-      }
-  
-      if (Array.isArray(data)) {
-        setParkings(data);
-      } else {
-        console.log("DATA IS NOT ARRAY:", data);
-        setParkings([]);
-      }
-  
-    } catch (error) {
-      console.log("FETCH ERROR:", error);
+  try {
+    const data = await getAllParkingsRequest();
+
+    if (Array.isArray(data)) {
+      setParkings(data);
+    } else {
       setParkings([]);
-    } finally {
-      setLoading(false);
     }
-  };
+  } catch (error) {
+    console.log("Parking fetch error:", error);
+    setParkings([]);
+  } finally {
+    setLoading(false);
+  }
+};
 
   
 

--- a/parkulator-frontend/context/AuthContext.tsx
+++ b/parkulator-frontend/context/AuthContext.tsx
@@ -1,13 +1,6 @@
 import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-
-const API_URL = 'http://192.168.1.4:8080'; // izvuci u config poslije
-
-type User = {
-  id: number;
-  email: string;
-  username: string;
-};
+import { getCurrentUserRequest, User } from "../services/user";
 
 type AuthResponse = {
   id: number;
@@ -89,17 +82,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         if (!token) return;
 
         try {
-          const res = await fetch(`${API_URL}/users/current`, {
-            headers: { Authorization: `Bearer ${token}` },
-          });
+          const fresh = await getCurrentUserRequest();
 
-          if (res.ok) {
-            const fresh: User = await res.json();
-            setUser(fresh);
-            await AsyncStorage.setItem(USER_KEY, JSON.stringify(fresh));
-          }
+          setUser(fresh);
+          await AsyncStorage.setItem(USER_KEY, JSON.stringify(fresh));
         } catch (e) {
-          console.log('Refresh user error:', e);
+          console.log("Refresh user error:", e);
         }
       },
 

--- a/parkulator-frontend/package-lock.json
+++ b/parkulator-frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
+        "axios": "^1.16.0",
         "expo": "~54.0.33",
         "expo-constants": "~18.0.13",
         "expo-font": "~14.0.11",
@@ -85,6 +86,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1466,6 +1468,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3051,6 +3054,7 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.2.2.tgz",
       "integrity": "sha512-kem1Ko2BcbAjmbQIv66dNmr6EtfDut3QU0qjsVhMnLLhktwyXb6FzZYp8gTrUb6AvkAbaJoi+BF5Pl55pAUa5w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.17.2",
         "escape-string-regexp": "^4.0.0",
@@ -3249,6 +3253,7 @@
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3319,6 +3324,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -3906,6 +3912,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4231,6 +4238,12 @@
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "license": "MIT"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -4245,6 +4258,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -4594,6 +4618,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4679,7 +4704,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4903,6 +4927,18 @@
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/commander": {
@@ -5224,6 +5260,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -5302,7 +5347,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -5431,7 +5475,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5441,7 +5484,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5480,7 +5522,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -5493,7 +5534,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5569,6 +5609,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5765,6 +5806,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6003,6 +6045,7 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.33.tgz",
       "integrity": "sha512-3yOEfAKqo+gqHcV8vKcnq0uA5zxlohnhA3fu4G43likN8ct5ZZ3LjAh9wDdKteEkoad3tFPvwxmXW711S5OHUw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.23",
@@ -6070,6 +6113,7 @@
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
       "integrity": "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@expo/config": "~12.0.13",
         "@expo/env": "~2.0.8"
@@ -6094,6 +6138,7 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.11.tgz",
       "integrity": "sha512-ga0q61ny4s/kr4k8JX9hVH69exVSIfcIc19+qZ7gt71Mqtm7xy2c6kwsPTCyhBW2Ro5yXTT8EaZOpuRi35rHbg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -6155,6 +6200,7 @@
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.11.tgz",
       "integrity": "sha512-+VSaNL5om3kOp/SSKO5qe6cFgfSIWnnQDSbA7XLs3ECkYzXRquk5unxNS3pg7eK5kNUmQ4kgLI7MhTggAEUBLA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "expo-constants": "~18.0.12",
         "invariant": "^2.2.4"
@@ -6869,6 +6915,26 @@
       "integrity": "sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==",
       "license": "MIT"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fontfaceobserver": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/fontfaceobserver/-/fontfaceobserver-2.3.0.tgz",
@@ -6889,6 +6955,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/freeport-async": {
@@ -7001,7 +7083,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -7044,7 +7125,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -7194,7 +7274,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7264,7 +7343,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7277,7 +7355,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -8806,7 +8883,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10095,6 +10171,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -10177,6 +10262,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10196,6 +10282,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -10232,6 +10319,7 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
       "integrity": "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.5",
@@ -10289,6 +10377,7 @@
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
       "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
@@ -10314,6 +10403,7 @@
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.7.tgz",
       "integrity": "sha512-Q4H6xA3Tn7QL0/E/KjI86I1KK4tcf+ErRE04LH34Etka2oVQhW6oXQ+Q8ZcDCVxiWp5vgbBH6XcH8BOo4w/Rhg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-native-is-edge-to-edge": "^1.2.1",
         "semver": "^7.7.2"
@@ -10341,6 +10431,7 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -10351,6 +10442,7 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
       "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
@@ -10366,6 +10458,7 @@
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.2.tgz",
       "integrity": "sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",
@@ -10398,6 +10491,7 @@
       "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
       "integrity": "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-class-properties": "^7.0.0-0",
@@ -10508,6 +10602,7 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11801,6 +11896,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12007,6 +12103,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/parkulator-frontend/package.json
+++ b/parkulator-frontend/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web",
     "lint": "expo lint"
   },
@@ -16,6 +16,7 @@
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
+    "axios": "^1.16.0",
     "expo": "~54.0.33",
     "expo-constants": "~18.0.13",
     "expo-font": "~14.0.11",
@@ -41,9 +42,9 @@
   },
   "devDependencies": {
     "@types/react": "~19.1.0",
-    "typescript": "~5.9.2",
     "eslint": "^9.25.0",
-    "eslint-config-expo": "~10.0.0"
+    "eslint-config-expo": "~10.0.0",
+    "typescript": "~5.9.2"
   },
   "private": true
 }

--- a/parkulator-frontend/services/api.ts
+++ b/parkulator-frontend/services/api.ts
@@ -1,14 +1,14 @@
 import axios from "axios";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
-const API_URL = "http://10.0.2.2:8080";
+const PARKULATOR_URL = "http://10.0.2.2:8080";
 // Android emulator: 10.0.2.2
-// Ako testiraš na fizičkom mobitelu, ovdje ide IP od tvog računala, npr. http://192.168.1.5:8080
+// If testing on physical phone, use the IP of your computer, e.g., http://192.168.1.5:8080
 
 const TOKEN_KEY = "auth_token";
 
 const api = axios.create({
-  baseURL: API_URL,
+  baseURL: PARKULATOR_URL,
   headers: {
     "Content-Type": "application/json",
   },

--- a/parkulator-frontend/services/api.ts
+++ b/parkulator-frontend/services/api.ts
@@ -1,24 +1,38 @@
+import axios from "axios";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
-const API_URL = 'http://192.168.1.105:8080'; 
+const API_URL = "http://10.0.2.2:8080";
 // Android emulator: 10.0.2.2
 // Ako testiraš na fizičkom mobitelu, ovdje ide IP od tvog računala, npr. http://192.168.1.5:8080
 
 const TOKEN_KEY = "auth_token";
 
-export async function authFetch(path: string, options: RequestInit = {}) {
+const api = axios.create({
+  baseURL: API_URL,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+api.interceptors.request.use(async (config) => {
   const token = await AsyncStorage.getItem(TOKEN_KEY);
 
-  const headers = {
-    "Content-Type": "application/json",
-    ...(options.headers || {}),
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-  };
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
 
-  const response = await fetch(`${API_URL}${path}`, {
-    ...options,
-    headers,
-  });
+  return config;
+});
 
-  return response;
+export function getApiErrorMessage(error: unknown, fallback = "Something went wrong") {
+  if (axios.isAxiosError(error)) {
+    const data = error.response?.data;
+
+    if (typeof data === "string") return data;
+    if (data?.message) return data.message;
+  }
+
+  return fallback;
 }
+
+export default api;

--- a/parkulator-frontend/services/auth.ts
+++ b/parkulator-frontend/services/auth.ts
@@ -1,6 +1,5 @@
-const API_URL = 'http://192.168.1.105:8080'; 
-// Android emulator: 10.0.2.2
-// Ako testiraš na fizičkom mobitelu, ovdje ide IP od tvog računala, npr. http://192.168.1.5:8080
+import api from "./api";
+
 
 type LoginPayload = {
   email: string;
@@ -21,35 +20,11 @@ export type AuthResponse = {
 };
 
 export async function loginRequest(payload: LoginPayload): Promise<AuthResponse> {
-  const response = await fetch(`${API_URL}/auth/login`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(payload),
-  });
-
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(text || 'Login failed');
-  }
-
-  return response.json();
+  const response = await api.post<AuthResponse>("/auth/login", payload);
+  return response.data;
 }
 
 export async function registerRequest(payload: RegisterPayload): Promise<AuthResponse> {
-  const response = await fetch(`${API_URL}/auth/register`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(payload),
-  });
-
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(text || 'Registration failed');
-  }
-
-  return response.json();
+  const response = await api.post<AuthResponse>("/auth/register", payload);
+  return response.data;
 }

--- a/parkulator-frontend/services/parking.ts
+++ b/parkulator-frontend/services/parking.ts
@@ -1,0 +1,28 @@
+import api from "./api";
+
+export type Parking = {
+  id: number;
+  name: string;
+  address?: string;
+  price?: number;
+  availableSpots?: number;
+  latitude?: number;
+  longitude?: number;
+
+  sourceKey: string;
+  link: string;
+  type: string;
+  isLive?: boolean;
+  totalSpots?: number;
+  occupiedSpots?: number;
+};
+
+export async function getAllParkingsRequest(): Promise<Parking[]> {
+  const response = await api.get<Parking[]>("/parkings/all");
+  return response.data;
+}
+
+/*export async function getParkingByIdRequest(id: number) {
+  const response = await api.get(`/parkings/${id}`);
+  return response.data;
+}*/

--- a/parkulator-frontend/services/user.ts
+++ b/parkulator-frontend/services/user.ts
@@ -1,16 +1,27 @@
-import { authFetch } from "./api";
+import api from "./api";
 
-export async function getCurrentUserRequest() {
-  const response = await authFetch("/users/current", {
-    method: "GET",
+export type User = {
+  id: number;
+  email: string;
+  username: string;
+};
+
+export async function getCurrentUserRequest(): Promise<User> {
+  const response = await api.get<User>("/users/current");
+  return response.data;
+}
+
+export async function updateUsernameRequest(username: string): Promise<void> {
+  await api.put("/users/username", { username });
+}
+
+export async function updateEmailRequest(email: string): Promise<void> {
+  await api.put("/users/email", { email });
+}
+
+export async function updatePasswordRequest(oldPassword: string, newPassword: string): Promise<void> {
+  await api.put("/users/password", {
+    oldPassword,
+    newPassword,
   });
-
-  const text = await response.text();
-  const data = text ? JSON.parse(text) : null;
-
-  if (!response.ok) {
-    throw new Error(data?.message || "Failed to load current user");
-  }
-
-  return data;
 }


### PR DESCRIPTION
Refactor frontend HTTP communication so all backend requests go through a centralized Axios client.

Completed:

Added a centralized Axios client in services/api.ts
Moved authentication routes to services/auth.ts
Moved user/profile routes to services/user.ts
Moved parking/data routes to services/parking.ts
Removed duplicated direct fetch calls from login, register, profile update, and data fetching flows
Backend base URL is now managed in one place

Closes #48